### PR TITLE
Add docs for Cloud Functions

### DIFF
--- a/docs/cloud_functions_cat.md
+++ b/docs/cloud_functions_cat.md
@@ -1,0 +1,35 @@
+# Funcions Cloud de Fix My Road
+
+Aquest document recull el codi de les funcions Cloud utilitzades al projecte i explica breument com funcionen i com es poden cridar. Els fitxers `record_function.js` i `trigger_yolo_function.js` contenen el codi complet.
+
+## Què són les Cloud Functions?
+
+Les Google Cloud Functions permeten executar fragments de codi en resposta a peticions HTTP o esdeveniments sense haver de gestionar cap servidor. S'escalen automàticament i es despleguen de forma senzilla.
+
+## Funció `uploadVideo`
+
+Es troba a `multimedia_system/public_html/record/index.js` i es pot veure íntegra a `docs/record_function.js`. Defineix dues rutes HTTP:
+
+- `POST /upload-video`: rep un vídeo i el desa al bucket `fixmyroad-videos` dins de la carpeta `videos/` amb el nom indicat al paràmetre `baseVideoName`.
+- `POST /upload-positions`: rep un JSON amb coordenades i el desa a `positions/` amb el nom indicat al paràmetre `basePositionsName`.
+
+S'exposa com a Cloud Function HTTP sota el nom `uploadVideo`.
+
+### Invocació
+
+Una vegada desplegada, es pot cridar via peticions HTTP. Per exemple:
+
+```bash
+curl -X POST "https://REGIO-PROJECTID.cloudfunctions.net/uploadVideo/upload-video?baseVideoName=123" \
+     --data-binary @video.webm \
+     -H "Content-Type: video/webm"
+```
+
+## Funció `processVideo`
+
+Ubicada a `multimedia_system/public_html/yolo/triggerYolo/index.js` (també copiada a `docs/trigger_yolo_function.js`). S'activa automàticament quan es puja un arxiu a `videos/` en el bucket. Envia la informació a un servei de Cloud Run perquè processi el vídeo amb YOLO.
+
+### Invocació
+
+No es crida manualment. Cada cop que es puja un vídeo al bucket, Google Cloud Storage genera un esdeveniment *Object Finalize* que executa aquesta funció.
+

--- a/docs/record_function.js
+++ b/docs/record_function.js
@@ -1,0 +1,92 @@
+// Se importan las librerías necesarias:
+// - `@google-cloud/functions-framework`: para declarar funciones HTTP en Cloud Functions.
+// - `express`: para manejar rutas HTTP de forma más estructurada.
+// - `cors`: para permitir llamadas desde cualquier origen (CORS).
+// - `@google-cloud/storage`: para interactuar con Cloud Storage.
+const functions = require('@google-cloud/functions-framework');
+const express = require('express');
+const cors = require('cors');
+const { Storage } = require('@google-cloud/storage');
+
+// Se inicializa la app con CORS permitido para todos los orígenes.
+// También se prepara el bucket donde se almacenarán los archivos.
+const app = express();
+app.use(cors({ origin: '*' }));
+
+const storage = new Storage();
+const bucket = storage.bucket('fixmyroad-videos');
+
+// Antes de llegar a las rutas, se imprime por consola el método y la ruta de cada petición recibida.
+// Útil para depuración y trazabilidad.
+app.use((req, res, next) => {
+  console.log('📥 Petición:', req.method, req.path);
+  next();
+});
+
+// Esta ruta recibe archivos binarios de tipo video mediante POST.
+// El nombre base del archivo se espera como parámetro en la query (`baseVideoName`).
+// Guarda el archivo en el bucket con extensión `.webm`.
+app.post(
+  '/upload-video',
+  express.raw({ type: 'video/*', limit: '512mb' }),
+  async (req, res) => {
+    const basename = req.query.baseVideoName;
+    console.log('🧩 Nombre desde query (video):', basename);
+
+    if (!req.body || !req.body.length || !basename) {
+      return res
+        .status(400)
+        .json({ error: 'Faltan datos: vídeo o parámetro baseVideoName' });
+    }
+
+    const filename = `videos/${basename}.webm`;
+    const file = bucket.file(filename);
+
+    try {
+      await file.save(req.body, {
+        metadata: { contentType: req.headers['content-type'] },
+        resumable: false
+      });
+      console.log(`✅ Subido vídeo: ${filename}`);
+      res.json({ ok: true, filename });
+    } catch (err) {
+      console.error('❌ Error subiendo vídeo:', err);
+      res.status(500).json({ error: 'Error subiendo vídeo' });
+    }
+  }
+);
+
+// Esta ruta recibe un JSON con un array de posiciones GPS y las guarda como archivo .json en el bucket.
+// El nombre base del archivo también se recibe como parámetro en la query (`basePositionsName`).
+app.post(
+  '/upload-positions',
+  express.json(),
+  async (req, res) => {
+    const basename = req.query.basePositionsName;
+    console.log('🧩 Nombre desde query (positions):', basename);
+
+    if (!Array.isArray(req.body) || !basename) {
+      return res
+        .status(400)
+        .json({ error: 'Faltan datos: posiciones o parámetro basePositionsName' });
+    }
+
+    const filename = `positions/${basename}.json`;
+    const file = bucket.file(filename);
+
+    try {
+      await file.save(JSON.stringify(req.body, null, 2), {
+        metadata: { contentType: 'application/json' },
+        resumable: false
+      });
+      console.log(`✅ Subidas posiciones: ${filename}`);
+      res.json({ ok: true, filename });
+    } catch (err) {
+      console.error('❌ Error subiendo posiciones:', err);
+      res.status(500).json({ error: 'Error subiendo posiciones' });
+    }
+  }
+);
+
+// Se expone la app de Express como una Cloud Function con el nombre `uploadVideo`.
+functions.http('uploadVideo', app);

--- a/docs/trigger_yolo_function.js
+++ b/docs/trigger_yolo_function.js
@@ -1,0 +1,18 @@
+const functions = require('@google-cloud/functions-framework');
+const fetch = require('node-fetch');
+
+functions.cloudEvent('processVideo', async (cloudEvent) => {
+  const { bucket, name } = cloudEvent.data;
+
+  if (!name.startsWith('videos/')) return;
+
+  const filename = name.split('/').pop();                
+  const baseName = filename.replace('_video.webm', '');  
+  const userId   = baseName.split('_')[0];               
+
+  await fetch('https://yolo-processor-322599195853.europe-southwest1.run.app/process', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ bucket, userId, baseName })
+  });
+});


### PR DESCRIPTION
## Summary
- add `docs/record_function.js` and `docs/trigger_yolo_function.js` with the Cloud Function code
- add `docs/cloud_functions_cat.md` explaining what Cloud Functions are and how to invoke them in Catalan

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841e3e36308832293a3a73061734e5d